### PR TITLE
Remove numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ By orchestrating these components, the module creates a well-structured and secu
 
 ## Input Variables
 
-1. `vpc_cdir:` Required input of type `string` that represents the CIDR Block Range for the VPC network. Users must specify the valid CIDR range they want to use for their VPC.
+ `vpc_cdir:` Required input of type `string` that represents the CIDR Block Range for the VPC network. Users must specify the valid CIDR range they want to use for their VPC.
 
-1. `project_name:` Required input of type `string` that allows users to define the project name that will be utilizing this module. It helps in identifying and organizing resources associated with the specific project.
+`project_name:` Required input of type `string` that allows users to define the project name that will be utilizing this module. It helps in identifying and organizing resources associated with the specific project.
 
-1. `environment:` Required input of type `string` that defines the workspace under which the network is provisioned. This variable is useful for managing multiple environments like production, staging, and development.
+`environment:` Required input of type `string` that defines the workspace under which the network is provisioned. This variable is useful for managing multiple environments like production, staging, and development.
 
-1. `subnet_cdir:` Required input of type `map(list)` that expects a mapping of subnets, where each key is a subnet name and each value is a list of CIDR Block Ranges for that subnet. This allows users to specify multiple subnets and their respective CIDR ranges within the module.
+`subnet_cdir:` Required input of type `map(list)` that expects a mapping of subnets, where each key is a subnet name and each value is a list of CIDR Block Ranges for that subnet. This allows users to specify multiple subnets and their respective CIDR ranges within the module.
 
 Additionally, the module provides optional input variables:
 
-1. `web_server_port:` This optional input of type `string` that allows users to specify a custom port for the Web Security Group. If left unset (or set as null), it defaults to port `80`, providing a convenient default value.
+`web_server_port:` This optional input of type `string` that allows users to specify a custom port for the Web Security Group. If left unset (or set as null), it defaults to port `80`, providing a convenient default value.
 
-1. `db_server_port:` This optional input of type `string` that permits users to define a custom port for the Database Security Group. If not specified (or set as null), it defaults to port `80`.
+`db_server_port:` This optional input of type `string` that permits users to define a custom port for the Database Security Group. If not specified (or set as null), it defaults to port `80`.
 
 By utilizing these input variables, users have the flexibility to tailor the module's behavior to their specific requirements and create VPC networks with custom configurations and security group port settings.
 


### PR DESCRIPTION
## Context

This PR removes number formatting from the input variable section because it is  inconsistent with the other sections of the documentation. 