### PR TITLE
A a default port feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Additionally, the module provides optional input variables:
 
 `web_server_port:` This optional input of type `string` that allows users to specify a custom port for the Web Security Group. If left unset (or set as null), it defaults to port `80`, providing a convenient default value.
 
-`db_server_port:` This optional input of type `string` that permits users to define a custom port for the Database Security Group. If not specified (or set as null), it defaults to port `80`.
+`database:` is a required input of type `string` that permits users to define a database port for the DB Security Group. supports `mysql`, `postgresql`, `mongodb`
+
+`db_server_port:` is an optional input of type `string` that permits users to define a custom port for the DB Security Group. If set, it overrides `database` else if set to `null` it defaults to `database`.
 
 `ipaddr` is a required input of type `string`, enabling users to specify the IP address of the host that will access the servers via SSH. This parameter is essential for establishing secure remote access to the servers and managing the infrastructure effectively.
 

--- a/security.tf
+++ b/security.tf
@@ -2,6 +2,16 @@
 ############## RESOURCES #################
 ##########################################
 
+locals {
+  databases = {
+    "postgresql" = 5432
+    "mysql" = 3306
+    "mongodb" = 27017
+  }
+  db_http_port = coalesce(var.db_server_port, local.databases[var.database])
+  web_http_port = coalesce(var.web_server_port, 80)
+}
+
 resource "aws_security_group" "lb-security-group" {
 
   name        = "${var.project_name}_lb_firewall"
@@ -10,8 +20,8 @@ resource "aws_security_group" "lb-security-group" {
 
   ingress {
     description = "Allow traffic from the internet"
-    from_port   = var.web_server_port
-    to_port     = var.web_server_port
+    from_port   = local.web_http_port
+    to_port     = local.web_http_port
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
@@ -44,8 +54,8 @@ resource "aws_security_group" "web-security-group" {
 
   ingress {
     description = "Allow traffic from Loadbalancer SG"
-    from_port   = var.web_server_port
-    to_port     = var.web_server_port
+    from_port   = local.web_http_port
+    to_port     = local.web_http_port
     protocol    = "tcp"
     security_groups = [aws_security_group.lb-security-group.id]
   }
@@ -86,8 +96,8 @@ resource "aws_security_group" "db-security-group" {
 
   ingress {
     description     = "Allow traffic from web SG"
-    from_port       = var.db_server_port
-    to_port         = var.db_server_port
+    from_port       = local.db_http_port
+    to_port         = local.db_http_port
     protocol        = "tcp"
     security_groups = [aws_security_group.web-security-group.id]
   }

--- a/variable.tf
+++ b/variable.tf
@@ -8,7 +8,8 @@ variable "subnet_cdir" {}
 
 variable "web_server_port" {}
 
+variable "database" {}
+
 variable "db_server_port" {}
 
 variable "ipaddr" {}
-


### PR DESCRIPTION
## Context

Instead of hard coding port values for Security Group ingress rules. This PR creates a feature to allow the defaulting of port values in case a user doesn't specify a one(leaves it as null).

**Contraints:**
- If the web_server_port =null it defaults to port 80
- `database` adds a default port.
- if db_server_port != null it overrides `database`, allowing user to add a custom port.